### PR TITLE
Fix nan cursor

### DIFF
--- a/src/test/suite/util.test.ts
+++ b/src/test/suite/util.test.ts
@@ -204,7 +204,7 @@ suite('Util Test Suite', () => {
         assert.strictEqual(undefined, util.traverseUntilUnmatchedParen(String.raw`(1, "5", 9)`, 11, 1));
     });
 
-    test('moveCursor', () => {
+    test('moveCursor.nested', () => {
         assert.strictEqual(undefined, util.moveCursor(String.raw`(1, (5, 8))`, 0, -1));
         assert.strictEqual(1, util.moveCursor(String.raw`(1, (5, 8))`, 1, -1));
         assert.strictEqual(1, util.moveCursor(String.raw`(1, (5, 8))`, 2, -1));

--- a/src/test/suite/util.test.ts
+++ b/src/test/suite/util.test.ts
@@ -231,6 +231,31 @@ suite('Util Test Suite', () => {
         assert.strictEqual(10, util.moveCursor(String.raw`(1, (5, 8))`, 10, 1));
         assert.strictEqual(undefined, util.moveCursor(String.raw`(1, (5, 8))`, 11, 1));
     });
+    test('moveCursor.string', () => {
+        assert.strictEqual(undefined, util.moveCursor(String.raw`("23", 78)`, 0, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 1, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 2, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 3, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 4, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 5, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 6, -1));
+        assert.strictEqual(1, util.moveCursor(String.raw`("23", 78)`, 7, -1));
+        assert.strictEqual(7, util.moveCursor(String.raw`("23", 78)`, 8, -1));
+        assert.strictEqual(7, util.moveCursor(String.raw`("23", 78)`, 9, -1));
+        assert.strictEqual(undefined, util.moveCursor(String.raw`("23", 78)`, 10, -1));
+
+        assert.strictEqual(undefined, util.moveCursor(String.raw`("23", 78)`, 0, 1));
+        assert.strictEqual(5, util.moveCursor(String.raw`("23", 78)`, 1, 1));
+        assert.strictEqual(5, util.moveCursor(String.raw`("23", 78)`, 2, 1));
+        assert.strictEqual(5, util.moveCursor(String.raw`("23", 78)`, 3, 1));
+        assert.strictEqual(5, util.moveCursor(String.raw`("23", 78)`, 4, 1));
+        assert.strictEqual(9, util.moveCursor(String.raw`("23", 78)`, 5, 1));
+        assert.strictEqual(9, util.moveCursor(String.raw`("23", 78)`, 6, 1));
+        assert.strictEqual(9, util.moveCursor(String.raw`("23", 78)`, 7, 1));
+        assert.strictEqual(9, util.moveCursor(String.raw`("23", 78)`, 8, 1));
+        assert.strictEqual(9, util.moveCursor(String.raw`("23", 78)`, 9, 1));
+        assert.strictEqual(undefined, util.moveCursor(String.raw`("23", 78)`, 10, 1));
+    });
 
     test('selectAtCursor.basic', () => {
         assert.deepStrictEqual(undefined, util.selectAtCursor(String.raw`(123, 67)`, 0));

--- a/src/util.ts
+++ b/src/util.ts
@@ -183,10 +183,11 @@ export function moveCursor(text: string, cursorOffset: number, dir: -1 | 1): num
         return undefined;
     }
 
-    let endOffset = traverseUntilUnmatchedParen(text, cursorOffset, dir)! - Math.min(0, dir);
+    const currentStringType = getCurrentStringType(text, cursorOffset);
+    let endOffset = traverseUntilUnmatchedParen(text, cursorOffset, dir, { currentStringType })! - Math.min(0, dir);
 
     if (dir === 1 && endOffset <= cursorOffset || dir === -1 && endOffset >= cursorOffset) {
-        endOffset = traverseUntilUnmatchedParen(text, cursorOffset, dir, { skipDelims: 1 })! - Math.min(0, dir);
+        endOffset = traverseUntilUnmatchedParen(text, cursorOffset, dir, { skipDelims: 1, currentStringType })! - Math.min(0, dir);
     }
 
     return endOffset;


### PR DESCRIPTION
Fixes #4, which also fixes #3, which was seemingly caused by:
1. forgetting to pass `currentStringType` to `traverseUntilUnmatchedParen` inside `moveCursor`
2. causing the returned value to be `undefined`
3. which became `NaN` when `dir` was added to it
4. which silently worked its way into the returned Selection
5. which was reset on most key inputs, but otherwise persisted and found its way into the next command call